### PR TITLE
Fix bug related to once animations

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -45,6 +45,7 @@ impl SpriteSheetAnimationState {
             } else if matches!(animation.mode, AnimationMode::Repeat) {
                 self.current_frame = 0;
             } else {
+                self.current_frame = 0;
                 return true;
             }
 


### PR DESCRIPTION
If we do not set `self.current_frame = 0;` when a `Once` animation has finished, then the animation is never able to be executed again.

With this update, the animation is able to be properly restarted next time the `Play` component is added to the corresponding entity.